### PR TITLE
Fixed decoding of negative integer

### DIFF
--- a/puresnmp/test/x690/test_types.py
+++ b/puresnmp/test/x690/test_types.py
@@ -242,6 +242,16 @@ class TestInteger(ByteTester):
         expected = Integer(0)
         self.assertEqual(result, expected)
 
+    def test_decoding_minus_one(self):
+        result = Integer.from_bytes(b"\x02\x01\xff")
+        expected = Integer(-1)
+        self.assertEqual(result, expected)
+
+    def test_decoding_minus_large_value(self):
+        result = Integer.from_bytes(b"\x02\x04\x8d\xf4\x73\xc1")
+        expected = Integer(-1913359423)
+        self.assertEqual(result, expected)
+
     def test_pythonize(self):
         result = Integer(1).pythonize()
         expected = 1

--- a/puresnmp/x690/types.py
+++ b/puresnmp/x690/types.py
@@ -362,7 +362,7 @@ class Integer(Type):
 
     @classmethod
     def decode(cls, data):
-        return cls(int.from_bytes(data, 'big'))
+        return cls(int.from_bytes(data, 'big', signed=True))
 
     def __init__(self, value):
         self.value = value


### PR DESCRIPTION
Hello,

I discovered a bug in Integer decoding.
It's the decoding part of #27  .
Per [RFC 2578](https://tools.ietf.org/html/rfc2578#section-7.1.1), an Integer (and Integer32) should be signed.

I made a simple fix in the Integer class and added two test to cover this case.

Thank you.