### PR TITLE
puresnmp/__init__.py: py2

### DIFF
--- a/puresnmp/__init__.py
+++ b/puresnmp/__init__.py
@@ -48,7 +48,8 @@ BulkResult = namedtuple('BulkResult', 'scalars listing')
 LOG = logging.getLogger(__name__)
 
 
-def get(ip: str, community: str, oid: str, port: int=161, timeout: int=2):
+def get(ip, community, oid, port=161, timeout=2):
+    # type: ( str, str, str, int, int )
     """
     Executes a simple SNMP GET request and returns a pure Python data structure.
 
@@ -60,8 +61,8 @@ def get(ip: str, community: str, oid: str, port: int=161, timeout: int=2):
     return multiget(ip, community, [oid], port, timeout=timeout)[0]
 
 
-def multiget(ip: str, community: str, oids: List[str], port: int=161,
-             timeout: int=2):
+def multiget(ip, community, oids, port=161, timeout=2):
+    # type: ( str, List[str], int, int )
     """
     Executes an SNMP GET request with multiple OIDs and returns a list of pure
     Python objects. The order of the output items is the same order as the OIDs
@@ -81,7 +82,7 @@ def multiget(ip: str, community: str, oids: List[str], port: int=161,
         GetRequest(get_request_id(), *oids)
     )
 
-    response = send(ip, port, bytes(packet), timeout=timeout)
+    response = send(ip, port, packet.to_bytes(), timeout=timeout)
     raw_response = Sequence.from_bytes(response)
 
     output = [value.pythonize() for _, value in raw_response[2].varbinds]
@@ -124,7 +125,7 @@ def multigetnext(ip, community, oids, port=161, timeout=2):
         OctetString(community),
         request
     )
-    response = send(ip, port, bytes(packet), timeout=timeout)
+    response = send(ip, port, packet.to_bytes(), timeout=timeout)
     raw_response = Sequence.from_bytes(response)
     response_object = raw_response[2]
     if len(response_object.varbinds) != len(oids):
@@ -135,7 +136,8 @@ def multigetnext(ip, community, oids, port=161, timeout=2):
             for oid, value in response_object.varbinds]
 
 
-def walk(ip: str, community: str, oid, port: int=161):
+def walk(ip, community, oid, port=161):
+    # type: ( str, str, , int )
     """
     Executes a sequence of SNMP GETNEXT requests and returns an generator over
     :py:class:`~puresnmp.pdu.VarBind` instances.
@@ -158,8 +160,8 @@ def walk(ip: str, community: str, oid, port: int=161):
     return multiwalk(ip, community, [oid], port)
 
 
-def multiwalk(ip: str, community: str, oids: List[str], port: int=161,
-              fetcher=multigetnext):
+def multiwalk(ip, community, oids, port=161, fetcher=multigetnext):
+    # type: ( str, str, List[str], int, )
     """
     Executes a sequence of SNMP GETNEXT requests and returns an generator over
     :py:class:`~puresnmp.pdu.VarBind` instances.
@@ -215,8 +217,8 @@ def multiwalk(ip: str, community: str, oids: List[str], port: int=161,
             yield varbind
 
 
-def set(ip: str, community: str, oid: str, value: Type, port: int=161,
-        timeout: int=2):
+def set(ip, community, oid, value, port=161, timeout=2):
+    # type: ( str, str, str, Type, int, int )
     """
     Executes a simple SNMP SET request. The result is returned as pure Python
     data structure. The value must be a subclass of
@@ -233,8 +235,8 @@ def set(ip: str, community: str, oid: str, value: Type, port: int=161,
     return result[oid]
 
 
-def multiset(ip: str, community: str, mappings: List[Tuple[str, Type]],
-             port: int=161, timeout: int=2):
+def multiset(ip, community, mappings, port=161, timeout=2):
+    # type: ( str, str, List[Tuple[str, Type]], int, int )
     """
 
     Executes an SNMP SET request on multiple OIDs. The result is returned as
@@ -258,7 +260,7 @@ def multiset(ip: str, community: str, mappings: List[Tuple[str, Type]],
     packet = Sequence(Integer(Version.V2C),
                       OctetString(community),
                       request)
-    response = send(ip, port, bytes(packet), timeout=timeout)
+    response = send(ip, port, packet.to_bytes(), timeout=timeout)
     raw_response = Sequence.from_bytes(response)
     output = {
         str(oid): value.pythonize() for oid, value in raw_response[2].varbinds
@@ -350,7 +352,7 @@ def bulkget(ip, community, scalar_oids, repeating_oids, max_list_size=1,
         BulkGetRequest(get_request_id(), non_repeaters, max_list_size, *oids)
     )
 
-    response = send(ip, port, bytes(packet), timeout=timeout)
+    response = send(ip, port, packet.to_bytes(), timeout=timeout)
     raw_response = Sequence.from_bytes(response)
 
     # See RFC=3416 for details of the following calculation
@@ -434,8 +436,8 @@ def bulkwalk(ip, community, oids, bulk_size=10, port=161):
         yield VarBind(oid, value)
 
 
-def table(ip: str, community: str, oid: str, port: int=161,
-          num_base_nodes: int=0):
+def table(ip, community, oid, port=161, num_base_nodes=0):
+    # type ( str, str, str, int, int )
     """
     Run a series of GETNEXT requests on an OID and construct a table from the
     result.

--- a/puresnmp/exc.py
+++ b/puresnmp/exc.py
@@ -33,9 +33,10 @@ class NoSuchOID(SnmpError):
 class TooManyVarbinds(SnmpError):
 
     def __init__(self, num_oids):
-        super().__init__('Too many VarBinds (%d) in one request! RFC3416 '
-                         'limits requests to %d!' % (
-                             num_oids, MAX_VARBINDS))
+        super(TooManyVarbinds, self).__init__(
+            'Too many VarBinds (%d) in one request!'
+            ' RFC3416 limits requests to %d!' % (
+                num_oids, MAX_VARBINDS))
         self.num_oids = num_oids
 
 

--- a/puresnmp/pdu.py
+++ b/puresnmp/pdu.py
@@ -12,6 +12,7 @@ their type identifier header (f.ex. ``b'\\xa0'`` for a
 #       "puresnmp.get", "puresnmp.walk" & co.
 
 from collections import namedtuple
+import six
 
 from .const import MAX_VARBINDS
 from .exc import SnmpError, EmptyMessage, NoSuchOID, TooManyVarbinds
@@ -30,12 +31,12 @@ from .x690.util import TypeInfo
 class VarBind(namedtuple('VarBind', 'oid, value')):
 
     def __new__(cls, oid, value):
-        if not isinstance(oid, (ObjectIdentifier, str)):
+        if not isinstance(oid, (ObjectIdentifier,) + six.string_types):
             raise TypeError('OIDs for VarBinds must be ObjectIdentifier or str'
                             ' instances!')
-        if isinstance(oid, str):
+        if isinstance(oid, six.string_types):
             oid = ObjectIdentifier.from_string(oid)
-        return super().__new__(cls, oid, value)
+        return super(VarBind, cls).__new__(cls, oid, value)
 
 
 ERROR_MESSAGES = {
@@ -75,7 +76,7 @@ class PDU(Type):
         :py:class:`~.PDU`.
         """
         # TODO (advanced): recent tests revealed that this is *not symmetric*
-        # with __bytes__ of this class. This should be ensured!
+        # with to_bytes of this class. This should be ensured!
         if not data:
             raise EmptyMessage('No data to decode!')
         request_id, data = pop_tlv(data)
@@ -106,7 +107,7 @@ class PDU(Type):
         else:
             self.varbinds = varbinds
 
-    def __bytes__(self):
+    def to_bytes(self):
         wrapped_varbinds = [Sequence(vb.oid, vb.value) for vb in self.varbinds]
         data = [
             Integer(self.request_id),
@@ -114,11 +115,11 @@ class PDU(Type):
             Integer(self.error_index),
             Sequence(*wrapped_varbinds)
         ]
-        payload = b''.join([bytes(chunk) for chunk in data])
+        payload = b''.join([bytes(chunk.to_bytes()) for chunk in data])
 
         tinfo = TypeInfo(TypeInfo.CONTEXT, TypeInfo.CONSTRUCTED, self.TAG)
         length = encode_length(len(payload))
-        return bytes(tinfo) + length + payload
+        return tinfo.to_bytes() + length + payload
 
     def __repr__(self):
         return '%s(%r, %r)' % (
@@ -131,7 +132,8 @@ class PDU(Type):
                 self.request_id == other.request_id and
                 self.varbinds == other.varbinds)
 
-    def pretty(self) -> str:  # pragma: no cover
+    def pretty(self):  # pragma: no cover
+        # type: () -> str
         """
         Returns a "prettified" string representing the SNMP message.
         """
@@ -163,7 +165,7 @@ class GetRequest(PDU):
                 wrapped_oids.append(ObjectIdentifier.from_string(oid))
             else:
                 wrapped_oids.append(oid)
-        super().__init__(request_id, [VarBind(oid, Null())
+        super(GetRequest, self).__init__(request_id, [VarBind(oid, Null())
                                       for oid in wrapped_oids])
 
 
@@ -181,7 +183,7 @@ class GetResponse(PDU):
         empty), raise a :py:exc:`~puresnmp.exc.NoSuchOID` exception.
         """
         try:
-            return super().decode(data)
+            return super(GetResponse, cls).decode(data)
         except EmptyMessage as exc:
             raise NoSuchOID('Nothing found at the given OID (%s)' % exc)
 
@@ -214,7 +216,7 @@ class BulkGetRequest(Type):
         an application object.
         """
         # TODO (advanced): recent tests revealed that this is *not symmetric*
-        # with __bytes__ of this class. This should be ensured!
+        # with to_bytes of this class. This should be ensured!
         if not data:
             raise EmptyMessage('No data to decode!')
         request_id, data = pop_tlv(data)
@@ -241,7 +243,7 @@ class BulkGetRequest(Type):
         for oid in oids:
             self.varbinds.append(VarBind(oid, Null()))
 
-    def __bytes__(self):
+    def to_bytes(self):
         wrapped_varbinds = [Sequence(vb.oid, vb.value) for vb in self.varbinds]
         data = [
             Integer(self.request_id),
@@ -249,11 +251,11 @@ class BulkGetRequest(Type):
             Integer(self.max_repeaters),
             Sequence(*wrapped_varbinds)
         ]
-        payload = b''.join([bytes(chunk) for chunk in data])
+        payload = b''.join([bytes(chunk.to_bytes()) for chunk in data])
 
         tinfo = TypeInfo(TypeInfo.CONTEXT, TypeInfo.CONSTRUCTED, self.TAG)
         length = encode_length(len(payload))
-        return bytes(tinfo) + length + payload
+        return tinfo.to_bytes() + length + payload
 
     def __repr__(self):
         return '%s(%r, %r)' % (
@@ -268,7 +270,8 @@ class BulkGetRequest(Type):
                 self.max_repeaters == other.max_repeaters and
                 self.varbinds == other.varbinds)
 
-    def pretty(self) -> str:  # pragma: no cover
+    def pretty(self):  # pragma: no cover
+        # type () -> str
         """
         Returns a "prettified" string representing the SNMP message.
         """

--- a/puresnmp/test/__init__.py
+++ b/puresnmp/test/__init__.py
@@ -1,6 +1,12 @@
-from itertools import zip_longest
+import sys
+try:
+    from itertools import zip_longest
+except ImportError:
+    from itertools import izip_longest as zip_longest
 from os.path import dirname, join
 import unittest
+
+_PY2 = sys.version_info.major < 3
 
 DATA_DIR = join(dirname(__file__), 'data')
 
@@ -13,11 +19,21 @@ class ByteTester(unittest.TestCase):
         """
         Helper method to compare bytes with more helpful output.
         """
-        if not isinstance(a, bytes) or not isinstance(b, bytes):
-            raise ValueError('assertBytesEqual requires two bytes objects!')
+        if not isinstance(a, (bytes,bytearray)) or not isinstance(b, (bytes,bytearray)):
+            raise ValueError('assertBytesEqual requires two bytes/bytearray objects!')
 
         if a != b:
             comparisons = []
+            type_a = type(a)
+            type_b = type(b)
+            a = bytearray(a)
+            b = bytearray(b)
+            def char_repr ( c ):
+                if 0x1f < char_a < 0x80:
+                    # bytearray to prevent accidental pre-mature str conv
+                    # str to prevent b'' suffix in repr's output
+                    return repr(str(bytearray( [char_a] ).decode( 'ascii' )))
+                return '.'
             for offset, (char_a, char_b) in enumerate(zip_longest(a, b)):
                 comp, marker = ('==', '') if char_a == char_b else ('!=', '>>')
 
@@ -25,24 +41,24 @@ class ByteTester(unittest.TestCase):
                 # unambiguous in this case, but we need to handle these
                 # separately from the main format string.
                 if char_a is None:
-                    char_ab = char_ad = char_ah = '?'
+                    char_ab = char_ad = char_ah = char_ar = '?'
                 else:
                     char_ab = '0b{:08b}'.format(char_a)
                     char_ad = '{:3d}'.format(char_a)
                     char_ah = '0x{:02x}'.format(char_a)
-
+                    char_ar = char_repr ( char_a )
                 if char_b is None:
-                    char_bb = char_bd = char_bh = '?'
+                    char_bb = char_bd = char_bh = char_br = '?'
                 else:
                     char_bb = '0b{:08b}'.format(char_b)
                     char_bd = '{:3d}'.format(char_b)
                     char_bh = '0x{:02x}'.format(char_b)
-
+                    char_br = char_repr ( char_b )
                 comparisons.append(
                     "{8:<3} Offset {0:4d}: "
                     "{1:^10} {4} {5:^10} | "
                     "{2:>3} {4} {6:>3} | "
-                    "{3:^4} {4} {7:^4}".format(
+                    "{3:^4} {4} {7:^4} | {9:>3} {4} {10:>3}".format(
                         offset,
                         char_ab,
                         char_ad,
@@ -51,12 +67,17 @@ class ByteTester(unittest.TestCase):
                         char_bb,
                         char_bd,
                         char_bh,
-                        marker))
+                        marker,
+                        char_ar,
+                        char_br))
             raise AssertionError('Bytes differ!\n' +
-                                 'type(a)=%s, type(b)=%s\n' % (type(a), type(b)) +
+                                 'type(a)=%s, type(b)=%s\n' % (type_a, type_b) +
                                  '\nIndividual bytes:\n' +
                                  '\n'.join(comparisons))
-
+    if _PY2:
+        assertRaisesRegex = unittest.TestCase.assertRaisesRegexp
+        def assertCountEqual ( self, result, expected ):
+            self.assertEqual ( len ( result ), len ( expected ) )
 
 def readbytes(filename):
     with open(join(DATA_DIR, filename)) as fp:
@@ -74,4 +95,4 @@ def readbytes(filename):
             line = line.split(':')[1]
         str_bytes.extend(line.split())
     values = [int(char, 16) for char in str_bytes]
-    return bytes(values)
+    return bytearray(values)

--- a/puresnmp/test/test_non_standard_types.py
+++ b/puresnmp/test/test_non_standard_types.py
@@ -14,7 +14,7 @@ class TestIpAddress(ByteTester):
 
     def test_encoding(self):
         value = t.IpAddress(b'\x80\x96\xa1\x09')
-        result = bytes(value)
+        result = value.to_bytes()
         expected = b'\x40\x04\x80\x96\xa1\x09'
         self.assertBytesEqual(result, expected)
 
@@ -44,7 +44,7 @@ class TestTimeTicks(ByteTester):
 
     def test_encoding(self):
         value = t.TimeTicks(100)
-        result = bytes(value)
+        result = value.to_bytes()
         expected = b'\x43\x01\x64'
         self.assertBytesEqual(result, expected)
 

--- a/puresnmp/test/test_package_root.py
+++ b/puresnmp/test/test_package_root.py
@@ -7,7 +7,10 @@ to use.
 
 
 from datetime import timedelta
-from unittest.mock import patch, call
+try:
+    from unittest.mock import patch, call
+except ImportError:
+    from mock import patch, call # pip install mock
 import unittest
 
 from puresnmp import (
@@ -33,10 +36,10 @@ from puresnmp.x690.types import (
     Sequence,
 )
 
-from . import readbytes
+from . import readbytes, ByteTester
 
 
-class TestGet(unittest.TestCase):
+class TestGet(ByteTester):
 
     def test_get_call_args(self):
         """
@@ -53,7 +56,7 @@ class TestGet(unittest.TestCase):
             mck2.return_value = 0
             mck.return_value = data
             get('::1', 'public', '1.2.3')
-            mck.assert_called_with('::1', 161, bytes(packet), timeout=2)
+            mck.assert_called_with('::1', 161, packet.to_bytes(), timeout=2)
 
     def test_get_string(self):
         data = readbytes('get_sysdescr_01.hex')
@@ -94,7 +97,7 @@ class TestGet(unittest.TestCase):
                 get('::1', 'private', '1.2.3')
 
 
-class TestWalk(unittest.TestCase):
+class TestWalk(ByteTester):
 
     def test_walk(self):
         response_1 = readbytes('walk_response_1.hex')
@@ -123,7 +126,7 @@ class TestWalk(unittest.TestCase):
                 next(walk('::1', 'private', '1.2.3'))
 
 
-class TestSet(unittest.TestCase):
+class TestSet(ByteTester):
 
     def test_set_without_type(self):
         """
@@ -169,7 +172,7 @@ class TestMultiGet(unittest.TestCase):
         self.assertEqual(result, expected)
 
 
-class TestMultiWalk(unittest.TestCase):
+class TestMultiWalk(ByteTester):
 
     def test_multi_walk(self):
         response_1 = readbytes('multiwalk_response_1.hex')
@@ -233,7 +236,7 @@ class TestGetNext(unittest.TestCase):
             mck2.return_value = 0
             mck.return_value = data
             getnext('::1', 'public', '1.2.3')
-            mck.assert_called_with('::1', 161, bytes(packet), timeout=2)
+            mck.assert_called_with('::1', 161, packet.to_bytes(), timeout=2)
 
     def test_getnext(self):
         data = readbytes('getnext_response.hex')
@@ -264,7 +267,7 @@ class TestGetBulkGet(unittest.TestCase):
                     ['1.2.3'],
                     ['1.2.4'],
                     max_list_size=2)
-            mck.assert_called_with('::1', 161, bytes(packet), timeout=2)
+            mck.assert_called_with('::1', 161, packet.to_bytes(), timeout=2)
 
 
     def test_bulkget(self):
@@ -305,7 +308,7 @@ class TestGetBulkWalk(unittest.TestCase):
             list(bulkwalk('::1', 'public',
                           ['1.2.3'],
                           bulk_size=2))
-            mck.assert_called_with('::1', 161, bytes(packet), timeout=2)
+            mck.assert_called_with('::1', 161, packet.to_bytes(), timeout=2)
 
 
     @patch('puresnmp.send')

--- a/puresnmp/test/test_pdus.py
+++ b/puresnmp/test/test_pdus.py
@@ -30,7 +30,7 @@ def comparable(bytes):
 class TestGet(ByteTester):
 
     def setUp(self):
-        super().setUp()
+        super(TestGet, self).setUp()
         self.maxDiff = None
 
     def test_get_request(self):
@@ -61,7 +61,7 @@ class TestGet(ByteTester):
             OctetString('public'),
             request
         )
-        result = bytes(packet)
+        result = packet.to_bytes()
 
         self.assertBytesEqual(result, expected)
 
@@ -125,7 +125,7 @@ class TestGet(ByteTester):
             request
         )
 
-        result = bytes(packet)
+        result = packet.to_bytes()
         self.assertBytesEqual(result, expected)
 
     def test_multiget_response(self):
@@ -170,7 +170,7 @@ class TestWalk(ByteTester):
             OctetString('public'),
             request
         )
-        result = bytes(packet)
+        result = packet.to_bytes()
         self.assertBytesEqual(result, expected)
 
 
@@ -189,7 +189,7 @@ class TestSet(ByteTester):
             OctetString('private'),
             request
         )
-        result = bytes(packet)
+        result = packet.to_bytes()
         self.assertBytesEqual(result, expected)
 
 
@@ -215,5 +215,5 @@ class TestBulkGet(ByteTester):
             request
         )
 
-        result = bytes(packet)
+        result = packet.to_bytes()
         self.assertBytesEqual(result, expected)

--- a/puresnmp/test/x690/test_types.py
+++ b/puresnmp/test/x690/test_types.py
@@ -1,7 +1,11 @@
+import sys
+
+_PY2 = sys.version_info.major == 2
+
 from ...x690.types import (
     Boolean,
     Integer,
-    NonASN1Type,
+    UnknownType,
     Null,
     ObjectIdentifier,
     OctetString,
@@ -17,13 +21,13 @@ class TestBoolean(ByteTester):
 
     def test_encoding_false(self):
         value = Boolean(False)
-        result = bytes(value)
+        result = value.to_bytes()
         expected = b'\x01\x01\x00'
         self.assertBytesEqual(result, expected)
 
     def test_encoding_true(self):
         value = Boolean(True)
-        result = bytes(value)
+        result = value.to_bytes()
         expected = b'\x01\x01\x01'
         self.assertBytesEqual(result, expected)
 
@@ -61,7 +65,7 @@ class TestBoolean(ByteTester):
 class TestObjectIdentifier(ByteTester):
 
     def setUp(self):
-        super().setUp()
+        super(TestObjectIdentifier, self).setUp()
         self.maxDiff = None
 
     def test_simple_encoding(self):
@@ -69,7 +73,7 @@ class TestObjectIdentifier(ByteTester):
         A simple OID with no identifier above 127
         """
         oid = ObjectIdentifier(1, 3, 6, 1, 2, 1)
-        result = bytes(oid)
+        result = oid.to_bytes()
         expected = b'\x06\x05\x2b\x06\x01\x02\x01'
         self.assertBytesEqual(result, expected)
 
@@ -87,7 +91,7 @@ class TestObjectIdentifier(ByteTester):
         bit weird. The sub-identifiers are split into multiple sub-identifiers.
         """
         oid = ObjectIdentifier(1, 3, 6, 8072)
-        result = bytes(oid)
+        result = oid.to_bytes()
         expected = b'\x06\x04\x2b\x06\xbf\x08'
         self.assertBytesEqual(result, expected)
 
@@ -126,7 +130,7 @@ class TestObjectIdentifier(ByteTester):
         self.assertEqual(result, expected)
 
     def test_encode_root(self):
-        result = bytes(ObjectIdentifier(1))
+        result = ObjectIdentifier(1).to_bytes()
         expected = b'\x06\x01\x01'
         self.assertBytesEqual(result, expected)
 
@@ -211,7 +215,7 @@ class TestInteger(ByteTester):
 
     def test_encoding(self):
         value = Integer(100)
-        result = bytes(value)
+        result = value.to_bytes()
         expected = b'\x02\x01\x64'
         self.assertBytesEqual(result, expected)
 
@@ -222,7 +226,7 @@ class TestInteger(ByteTester):
 
     def test_encoding_large_value(self):
         value = Integer(1913359423)
-        result = bytes(value)
+        result = value.to_bytes()
         expected = b"\x02\x04\x72\x0b\x8c\x3f"
         self.assertBytesEqual(result, expected)
 
@@ -233,7 +237,7 @@ class TestInteger(ByteTester):
 
     def test_encoding_zero(self):
         value = Integer(0)
-        result = bytes(value)
+        result = value.to_bytes()
         expected = b"\x02\x01\x00"
         self.assertBytesEqual(result, expected)
 
@@ -267,73 +271,73 @@ class TestIntegerValues(ByteTester):
         See https://github.com/exhuma/puresnmp/issues/27
         """
         value = Integer(32768)
-        result = bytes(value)
+        result = value.to_bytes()
         expected = b'\x02\x03\x00\x80\x00'
         self.assertBytesEqual(result, expected)
 
     def test_minus_one(self):
         value = Integer(-1)
-        result = bytes(value)
+        result = value.to_bytes()
         expected = b'\x02\x01\xff'
         self.assertBytesEqual(result, expected)
 
     def test_minus_two(self):
         value = Integer(-2)
-        result = bytes(value)
+        result = value.to_bytes()
         expected = b'\x02\x01\xfe'
         self.assertBytesEqual(result, expected)
 
     def test_zero(self):
         value = Integer(0)
-        result = bytes(value)
+        result = value.to_bytes()
         expected = b'\x02\x01\x00'
         self.assertBytesEqual(result, expected)
 
     def test_minus_16bit(self):
         value = Integer(-0b1111111111111111)
-        result = bytes(value)
+        result = value.to_bytes()
         expected = b'\x02\x03\xff\x00\x01'
         self.assertBytesEqual(result, expected)
 
     def test_minus_16bit_plus_one(self):
         value = Integer(-0b1111111111111111 + 1)
-        result = bytes(value)
+        result = value.to_bytes()
         expected = b'\x02\x03\xff\x00\x02'
         self.assertBytesEqual(result, expected)
 
     def test_minus_16bit_minus_one(self):
         value = Integer(-0b1111111111111111 - 1)
-        result = bytes(value)
+        result = value.to_bytes()
         expected = b'\x02\x03\xff\x00\x00'
         self.assertBytesEqual(result, expected)
 
     def test_minus_16bit_minus_two(self):
         value = Integer(-0b1111111111111111 - 2)
-        result = bytes(value)
+        result = value.to_bytes()
         expected = b'\x02\x03\xfe\xff\xff'
         self.assertBytesEqual(result, expected)
 
     def test_16bit(self):
         value = Integer(0b1111111111111111)
-        result = bytes(value)
+        result = value.to_bytes()
         expected = b'\x02\x03\x00\xff\xff'
         self.assertBytesEqual(result, expected)
 
     def test_16bitplusone(self):
         value = Integer(0b1111111111111111 + 1)
-        result = bytes(value)
+        result = value.to_bytes()
         expected = b'\x02\x03\x01\x00\x00'
         self.assertBytesEqual(result, expected)
 
     def test_16bitminusone(self):
         value = Integer(0b1111111111111111 - 1)
-        result = bytes(value)
+        result = value.to_bytes()
         expected = b'\x02\x03\x00\xff\xfe'
         self.assertBytesEqual(result, expected)
 
     def test_32bit(self):
         value = Integer(0b11111111111111111111111111111111)
-        result = bytes(value)
+        result = value.to_bytes()
         expected = b'\x02\x05\x00\xff\xff\xff\xff'
         self.assertBytesEqual(result, expected)
 
@@ -342,7 +346,7 @@ class TestString(ByteTester):
 
     def test_encoding(self):
         value = OctetString('hello')
-        result = bytes(value)
+        result = value.to_bytes()
         expected = b'\x04\x05hello'
         self.assertBytesEqual(result, expected)
 
@@ -365,15 +369,15 @@ class TestSequence(ByteTester):
             ObjectIdentifier(1, 3, 6),
             Integer(100)
         )
-        result = bytes(value)
+        result = value.to_bytes()
         expected = (
-            bytes([
+            bytearray([
                 0x30,
                 14,  # Expected length (note that an OID drops one byte)
             ]) +
-            bytes(OctetString('hello')) +
-            bytes(ObjectIdentifier(1, 3, 6)) +
-            bytes(Integer(100))
+            OctetString('hello').to_bytes() +
+            ObjectIdentifier(1, 3, 6).to_bytes() +
+            Integer(100).to_bytes()
         )
         self.assertBytesEqual(result, expected)
 
@@ -462,7 +466,7 @@ class TestNull(ByteTester):
             Null.validate(b'\x05\x01')
 
     def test_encoding(self):
-        result = bytes(Null())
+        result = Null().to_bytes()
         expected = b'\x05\x00'
         self.assertEqual(result, expected)
 
@@ -477,30 +481,33 @@ class TestNull(ByteTester):
         self.assertEqual(result, expected)
 
 
-class TestNonASN1Type(ByteTester):
+class TestUnknownType(ByteTester):
 
     def test_null_from_bytes(self):
-        result = NonASN1Type.from_bytes(b'')
+        result = UnknownType.from_bytes(b'')
         expected = Null()
         self.assertEqual(result, expected)
 
     def test_decoding(self):
         result, _ = pop_tlv(b'\x99\x01\x0a')
-        expected = NonASN1Type(0x99, b'\x0a')
+        expected = UnknownType(0x99, b'\x0a')
         self.assertEqual(result, expected)
 
     def test_encoding(self):
-        result = bytes(NonASN1Type(0x99, b'\x0a'))
-        expected = b'\x99\x01\x0a'
+        result = UnknownType(0x99, b'\x0a').to_bytes()
+        expected = bytearray(b'\x99\x01\x0a')
         self.assertEqual(result, expected)
 
     def test_decoding_corrupt_length(self):
         with self.assertRaisesRegex(ValueError, 'length'):
-            NonASN1Type.from_bytes(b'\x99\x02\x0a')
+            UnknownType.from_bytes(b'\x99\x02\x0a')
 
     def test_repr(self):
-        result = repr(NonASN1Type(99, b'abc'))
-        expected = "NonASN1Type(99, b'abc')"
+        result = repr(UnknownType(99, b'abc'))
+        if not _PY2:
+            expected = "UnknownType(99, b'abc')"
+        else:
+            expected = "UnknownType(99, 'abc')"
         self.assertEqual(result, expected)
 
 
@@ -515,13 +522,13 @@ class TestAllTypes(ByteTester):
         self.assertEqual(result, expected)
 
     def test_tlv_simple(self):
-        result = pop_tlv(bytes([2, 1, 0]))
+        result = pop_tlv(bytearray([2, 1, 0]))
         expected = (Integer(0), b'')
         self.assertEqual(result, expected)
 
     def test_tlv_unknown_type(self):
-        result = pop_tlv(bytes([254, 1, 0]))
-        expected = (NonASN1Type(254, b'\x00'), b'')
+        result = pop_tlv(bytearray([254, 1, 0]))
+        expected = (UnknownType(254, b'\x00'), b'')
         self.assertEqual(result, expected)
         self.assertEqual(result[0].tag, 254)
         self.assertEqual(result[0].length, 1)
@@ -529,7 +536,7 @@ class TestAllTypes(ByteTester):
 
     def test_validation_wrong_typeclass(self):
         with self.assertRaises(ValueError):
-            Integer.validate(bytes([0b00111110]))
+            Integer.validate(bytearray([0b00111110]))
 
     def test_null_from_bytes(self):
         result = Type.from_bytes(b'')

--- a/puresnmp/test/x690/test_util.py
+++ b/puresnmp/test/x690/test_util.py
@@ -65,50 +65,50 @@ class TestTypeInfoEncoding(ByteTester):
 
     def test_to_bytes_a(self):
         obj = TypeInfo(TypeInfo.UNIVERSAL, TypeInfo.PRIMITIVE, 0b11110)
-        result = bytes(obj)
-        expected = bytes([0b00011110])
+        result = obj.to_bytes()
+        expected = bytearray([0b00011110])
         self.assertEqual(result, expected)
 
     def test_to_bytes_b(self):
         obj = TypeInfo(TypeInfo.UNIVERSAL, TypeInfo.CONSTRUCTED, 0b11110)
-        result = bytes(obj)
-        expected = bytes([0b00111110])
+        result = obj.to_bytes()
+        expected = bytearray([0b00111110])
         self.assertEqual(result, expected)
 
     def test_to_bytes_c(self):
         obj = TypeInfo(TypeInfo.APPLICATION, TypeInfo.PRIMITIVE, 0b11110)
-        result = bytes(obj)
-        expected = bytes([0b01011110])
+        result = obj.to_bytes()
+        expected = bytearray([0b01011110])
         self.assertEqual(result, expected)
 
     def test_to_bytes_d(self):
         obj = TypeInfo(TypeInfo.APPLICATION, TypeInfo.CONSTRUCTED, 0b11110)
-        result = bytes(obj)
-        expected = bytes([0b01111110])
+        result = obj.to_bytes()
+        expected = bytearray([0b01111110])
         self.assertEqual(result, expected)
 
     def test_to_bytes_e(self):
         obj = TypeInfo(TypeInfo.CONTEXT, TypeInfo.PRIMITIVE, 0b11110)
-        result = bytes(obj)
-        expected = bytes([0b10011110])
+        result = obj.to_bytes()
+        expected = bytearray([0b10011110])
         self.assertEqual(result, expected)
 
     def test_to_bytes_f(self):
         obj = TypeInfo(TypeInfo.CONTEXT, TypeInfo.CONSTRUCTED, 0b11110)
-        result = bytes(obj)
-        expected = bytes([0b10111110])
+        result = obj.to_bytes()
+        expected = bytearray([0b10111110])
         self.assertEqual(result, expected)
 
     def test_to_bytes_g(self):
         obj = TypeInfo(TypeInfo.PRIVATE, TypeInfo.PRIMITIVE, 0b11110)
-        result = bytes(obj)
-        expected = bytes([0b11011110])
+        result = obj.to_bytes()
+        expected = bytearray([0b11011110])
         self.assertEqual(result, expected)
 
     def test_to_bytes_h(self):
         obj = TypeInfo(TypeInfo.PRIVATE, TypeInfo.CONSTRUCTED, 0b11110)
-        result = bytes(obj)
-        expected = bytes([0b11111110])
+        result = obj.to_bytes()
+        expected = bytearray([0b11111110])
         self.assertEqual(result, expected)
 
 
@@ -133,7 +133,7 @@ class TestTypeInfoClass(ByteTester):
         should yield the same instance.
         """
         expected = TypeInfo(TypeInfo.UNIVERSAL, TypeInfo.CONSTRUCTED, 0b11110)
-        result = TypeInfo.from_bytes(bytes(expected))
+        result = TypeInfo.from_bytes(expected.to_bytes())
         self.assertEqual(result, expected)
 
     def test_dencoding_symmetry_b(self):
@@ -141,45 +141,45 @@ class TestTypeInfoClass(ByteTester):
         Decoding an object from bytes, and then encoding the resulting instance
         should yield the same bytes.
         """
-        expected = bytes([0b11111110])
-        result = bytes(TypeInfo.from_bytes(expected))
+        expected = bytearray([0b11111110])
+        result = TypeInfo.from_bytes(expected).to_bytes()
         self.assertEqual(result, expected)
 
     def test_impossible_class(self):
         instance = TypeInfo(10, 100, 1000)
         with self.assertRaisesRegex(ValueError, 'class'):
-            bytes(instance)
+            instance.to_bytes()
 
     def test_impossible_pc(self):
         instance = TypeInfo(TypeInfo.APPLICATION, 100, 1000)
         with self.assertRaisesRegex(ValueError, 'primitive/constructed'):
-            bytes(instance)
+            instance.to_bytes()
 
 
 class TestLengthOctets(ByteTester):
 
     def test_encode_length_short(self):
-        expected = bytes([0b00100110])
+        expected = bytearray([0b00100110])
         result = encode_length(38)
         self.assertEqual(result, expected)
 
     def test_encode_length_long(self):
-        expected = bytes([0b10000001, 0b11001001])
+        expected = bytearray([0b10000001, 0b11001001])
         result = encode_length(201)
         self.assertBytesEqual(result, expected)
 
     def test_encode_length_longer(self):
-        expected = bytes([0b10000010, 0b00000001, 0b00101110])
+        expected = bytearray([0b10000010, 0b00000001, 0b00101110])
         result = encode_length(302)
         self.assertBytesEqual(result, expected)
 
     def test_encode_length_longer_2(self):
-        expected = bytes([0x81, 0xa4])
+        expected = bytearray([0x81, 0xa4])
         result = encode_length(164)
         self.assertBytesEqual(result, expected)
 
     def test_encode_length_indefinite(self):
-        expected = bytes([0b10000000])
+        expected = bytearray([0b10000000])
         result = encode_length(Length.INDEFINITE)
         self.assertBytesEqual(result, expected)
 
@@ -196,14 +196,14 @@ class TestLengthOctets(ByteTester):
         self.assertEqual(data, b'')
 
     def test_decode_length_long(self):
-        data = bytes([0b10000010, 0b00000001, 0b10110011])
+        data = bytearray([0b10000010, 0b00000001, 0b10110011])
         expected = 435
         result, data = decode_length(data)
         self.assertEqual(result, expected)
         self.assertEqual(data, b'')
 
     def test_decode_length_longer(self):
-        data = bytes([0x81, 0xa4])
+        data = bytearray([0x81, 0xa4])
         expected = 164
         result, data = decode_length(data)
         self.assertEqual(result, expected)
@@ -211,17 +211,17 @@ class TestLengthOctets(ByteTester):
 
     def test_decode_length_indefinite(self):
         with self.assertRaises(NotImplementedError):
-            decode_length(bytes([0b10000000]))
+            decode_length(bytearray([0b10000000]))
 
     def test_decode_length_reserved(self):
         with self.assertRaises(NotImplementedError):
-            decode_length(bytes([0b11111111]))
+            decode_length(bytearray([0b11111111]))
 
 
 class TestHelpers(ByteTester):
 
     def test_visible_octets_minimal(self):
-        result = visible_octets(bytes([0b00000000, 0b01010101]))
+        result = visible_octets(bytearray([0b00000000, 0b01010101]))
         expected = '00 55                                              .U'
         self.assertEqual(result, expected)
 
@@ -229,7 +229,7 @@ class TestHelpers(ByteTester):
         """
         Test that we have a double space after 8 octets for better readability
         """
-        result = visible_octets(bytes([
+        result = visible_octets(bytearray([
             0b00000000,
             0b01010101,
             0b00000000,
@@ -248,7 +248,7 @@ class TestHelpers(ByteTester):
         """
         If we have more than 16 octets, we need to go to a new line.
         """
-        result = visible_octets(bytes([0b00000000, 0b01010101] * 9))
+        result = visible_octets(bytearray([0b00000000, 0b01010101] * 9))
         expected = ('00 55 00 55 00 55 00 55  00 55 00 55 00 55 00 55   '
                     '.U.U.U.U.U.U.U.U\n'
                     '00 55                                              '
@@ -320,12 +320,12 @@ class TestGithubIssue23(ByteTester):
     """
 
     def test_encode(self):
-        expected = bytes([0b10000010, 0b00000001, 0b10110011])
+        expected = bytearray([0b10000010, 0b00000001, 0b10110011])
         result = encode_length(435)
         self.assertBytesEqual(result, expected)
 
     def test_decode(self):
-        data = bytes([0b10000010, 0b00000001, 0b10110011])
+        data = bytearray([0b10000010, 0b00000001, 0b10110011])
         expected = 435
         result, data = decode_length(data)
         self.assertEqual(result, expected)

--- a/puresnmp/transport.py
+++ b/puresnmp/transport.py
@@ -20,7 +20,8 @@ LOG = logging.getLogger(__name__)
 RETRIES = 3
 
 
-def send(ip: str, port: int, packet: bytes, timeout: int=2) -> bytes:  # pragma: no cover
+def send(ip, port, packet, timeout=2):  # pragma: no cover
+    # type: ( str, int, bytes, int ) -> bytes
     """
     Opens a TCP connection to *ip:port*, sends a packet with *bytes* and returns
     the raw bytes as returned from the remote host.

--- a/puresnmp/types.py
+++ b/puresnmp/types.py
@@ -48,7 +48,7 @@ class TimeTicks(Integer):
     def __init__(self, value):
         if isinstance(value, timedelta):
             value = int(value.total_seconds() * 100)
-        super().__init__(value)
+        super(TimeTicks, self).__init__(value)
 
     def pythonize(self):
         seconds = self.value / 100.0  # see rfc2578#section-7.1.8

--- a/puresnmp/x690/util.py
+++ b/puresnmp/x690/util.py
@@ -4,9 +4,23 @@ Utility functions for working with the X.690 and related standards.
 from binascii import hexlify, unhexlify
 from collections import namedtuple
 from typing import Tuple, Union, List, Any
+import codecs
 
 from ..const import Length
 
+try:
+    int_from_bytes = int.from_bytes
+except AttributeError:
+    def int_from_bytes(bytes, byteorder, signed=False):
+        bytes = bytearray ( bytes )
+        if byteorder == 'little':
+            little_ordered = list(bytes)
+        elif byteorder == 'big':
+            little_ordered = list(reversed(bytes))
+        n = sum(b << 8*i for i, b in enumerate(little_ordered))
+        if signed and little_ordered and (little_ordered[-1] & 0x80):
+             n -= 1 << 8*len(little_ordered)
+        return n
 
 LengthValue = namedtuple('LengthValue', 'length value')
 
@@ -38,7 +52,8 @@ class TypeInfo(namedtuple('TypeInfo', 'cls priv_const tag')):
     CONSTRUCTED = 'constructed'
 
     @staticmethod
-    def from_bytes(data: Union[int, bytes]) -> "TypeInfo":
+    def from_bytes(data):
+        # type: ( Union[int, bytes] ) -> TypeInfo
         """
         Given one octet, extract the separate fields and return a TypeInfo
         instance::
@@ -48,8 +63,8 @@ class TypeInfo(namedtuple('TypeInfo', 'cls priv_const tag')):
         """
         # pylint: disable=attribute-defined-outside-init
 
-        if isinstance(data, bytes):
-            data = int.from_bytes(data, 'big')
+        if isinstance(data, ( bytes, bytearray)):
+            data = int_from_bytes(data, 'big')
         # pylint: disable=protected-access
         if data == 0b11111111:
             raise NotImplementedError('Long identifier types are not yet '
@@ -75,7 +90,7 @@ class TypeInfo(namedtuple('TypeInfo', 'cls priv_const tag')):
         instance._raw_value = data
         return instance
 
-    def __bytes__(self):
+    def to_bytes(self):
         # pylint: disable=invalid-name
         if self.cls == TypeInfo.UNIVERSAL:
             cls = 0b00
@@ -96,10 +111,10 @@ class TypeInfo(namedtuple('TypeInfo', 'cls priv_const tag')):
             raise ValueError('Unexpected primitive/constructed for type info')
 
         output = cls << 6 | priv_const << 5 | self.tag
-        return bytes([output])
+        return bytearray([output])
 
     def __eq__(self, other):
-        return super().__eq__(other)
+        return super(TypeInfo, self).__eq__(other)
 
 
 def encode_length(value):
@@ -127,10 +142,10 @@ def encode_length(value):
         b'\\x81\\xc8'
     """
     if value == Length.INDEFINITE:
-        return bytes([0b10000000])
+        return bytearray([0b10000000])
 
     if value < 127:
-        return bytes([value])
+        return bytearray([value])
 
     output = []
     while value > 0:
@@ -139,10 +154,11 @@ def encode_length(value):
 
     # prefix length information
     output = [0b10000000 | len(output)] + output
-    return bytes(output)
+    return bytearray(output)
 
 
-def decode_length(data: bytes) -> LengthValue:
+def decode_length(data):
+    # type: ( bytes ) -> LengthValue
     """
     Given a bytes object, which starts with the length information of a TLV
     value, returns a namedtuple with the length and the remaining bytes. So,
@@ -168,26 +184,28 @@ def decode_length(data: bytes) -> LengthValue:
     TODO: Upon rereading this, I wonder if it would not make more sense to take
           the complete TLV content as input.
     """
+    data = bytearray(data)
     if data[0] == 0b11111111:
         # reserved
         raise NotImplementedError('This is a reserved case in X690')
     elif data[0] & 0b10000000 == 0:
         # definite short form
-        output = int.from_bytes([data[0]], 'big')
+        output = int_from_bytes([data[0]], 'big')
         data = data[1:]
     elif data[0] ^ 0b10000000 == 0:
         # indefinite form
-        raise NotImplementedError('Indefinite lenghts are not yet implemented!')
+        raise NotImplementedError('Indefinite lengths are not yet implemented!')
     else:
         # definite long form
-        num_octets = int.from_bytes([data[0] ^ 0b10000000], 'big')
+        num_octets = int_from_bytes([data[0] ^ 0b10000000], 'big')
         value_octets = data[1:1+num_octets]
-        output = int.from_bytes(value_octets, 'big')
+        output = int_from_bytes(value_octets, 'big')
         data = data[num_octets + 1:]
     return LengthValue(output, data)
 
 
-def visible_octets(data: bytes) -> str:
+def visible_octets(data):
+    # type: ( bytes ) -> str
     """
     Returns a geek-friendly (hexdump)  output of a bytes object.
 
@@ -231,7 +249,8 @@ def visible_octets(data: bytes) -> str:
     return '\n'.join(output)
 
 
-def tablify(varbinds: List[Tuple[Any, Any]], num_base_nodes: int=0) -> list:
+def tablify(varbinds, num_base_nodes=0):
+    # type: ( List[Tuple[Any, Any]], int ) -> list
     """
     Converts a list of varbinds into a table-like structure. *num_base_nodes*
     can be used for table which row-ids consist of multiple OID tree nodes. By


### PR DESCRIPTION
I have implemented py2 compatibility while making sure that all tests still work in py3

I noticed while going through it that you wanted NonASN1Type renamed to UnknownType so I took care of that, too.

While I was troubleshooting my changes, I had a desire to see the ascii representation of each byte in ByteTester.assertBytesEqual so I added an extra column with that information.

puresnmp/exc.py: py2
puresnmp/pdu.py: py2
puresnmp/test/__init__.py: py2, add repr() of each char to comparison output
puresnmp/tests/test_non_standard_types.py: py2
puresnmp/test/test_package_root.py: py2, switch some base classes to ByteTester b/c I implemented py2 unittest compatibility there
puresnmp/test/test_pdus.py: py2
puresnmp/test/x690/test_types.py: py2, rename NonASN1Type to UnknownType
puresnmp/test/x690/test_util.py: py2
puresnmp/transport.py: py2
puresnmp/types.py: py2
puresnmp/x690/types.py: py2
puresnmp/x690/util.py: py2