### PR TITLE
Added six to the dependencies in setup.py

### DIFF
--- a/puresnmp/version.py
+++ b/puresnmp/version.py
@@ -1,1 +1,1 @@
-VERSION = '1.3.2'
+VERSION = '1.3.2.post1'

--- a/setup.py
+++ b/setup.py
@@ -20,7 +20,8 @@ def get_version():
 
 VERSION = get_version()
 DEPENDENCIES = [
-    'verlib'
+    'verlib',
+    'six',
 ]
 if version_info < (3, 5):
     DEPENDENCIES.append('typing')


### PR DESCRIPTION
The six module is used in `puresnmp/x690/types.py`. This dependency needs to be enumerated in `setup.py`.