### PR TITLE
Added source address to received traps

### DIFF
--- a/puresnmp/api/pythonic.py
+++ b/puresnmp/api/pythonic.py
@@ -69,13 +69,19 @@ class TrapInfo:
     #:     ticket!
     raw_trap = None
 
-    def __init__(self, raw_trap):
+    def __init__(self, raw_trap, addr):
         # type: (Trap) -> None
         self.raw_trap = raw_trap
+        self.addr = addr
 
     def __repr__(self):
         # type: () -> str
-        return '<TrapInfo on %s with %d values>' % (self.oid, len(self.values))
+        return '<TrapInfo from %s on %s with %d values>' % (self.origin, self.oid, len(self.values))
+
+    @property
+    def origin(self):
+        return self.addr[0]
+    
 
     @property
     def uptime(self):
@@ -317,5 +323,5 @@ def traps(listen_address='0.0.0.0', port=162, buffer_size=1024):
     """
     A "pythonic" wrapper around :py:func:`puresnmp.api.raw.traps` output.
     """
-    for raw_trap in raw.traps(listen_address, port, buffer_size):
-        yield TrapInfo(raw_trap)
+    for raw_trap, addr in raw.traps(listen_address, port, buffer_size):
+        yield TrapInfo(raw_trap, addr)

--- a/puresnmp/api/raw.py
+++ b/puresnmp/api/raw.py
@@ -608,9 +608,9 @@ def traps(listen_address='0.0.0.0', port=162, buffer_size=1024):
     the body of the trap
     """
     transport = Transport(buffer_size=buffer_size)
-    for data in transport.listen(listen_address, port):
+    for data, addr in transport.listen(listen_address, port):
         obj = cast(
             Tuple[Any, Any, Trap],
             Sequence.from_bytes(data)
         )
-        yield obj[2]
+        yield obj[2], addr

--- a/puresnmp/transport.py
+++ b/puresnmp/transport.py
@@ -115,12 +115,12 @@ class Transport(object):
         with socket.socket(socket.AF_INET, socket.SOCK_DGRAM) as sock:
             sock.bind((bind_address, port))
             while True:
-                request, _ = sock.recvfrom(self.buffer_size)
+                request, addr = sock.recvfrom(self.buffer_size)
                 if LOG.isEnabledFor(logging.DEBUG):
                     hexdump = visible_octets(request)
                     LOG.debug('Received packet:\n%s', hexdump)
 
-                yield request
+                yield request, addr
 
     def get_request_id(self):  # pragma: no cover
         # type: () -> int


### PR DESCRIPTION
Some devices don't include the origin of the trap source as part of the PDU.

Added a minor patch to add the source of the received PDU to the TrapInfo class.