### PR TITLE
Fix version bit for SNMPv1

### DIFF
--- a/puresnmp_plugins/security/v1.py
+++ b/puresnmp_plugins/security/v1.py
@@ -36,7 +36,7 @@ class SNMPv1SecurityModel(SecurityModel[PDU, Sequence]):
         warn("Experimental SNMPv1 support", UserWarning)
 
         packet = Sequence(
-            [Integer(1), OctetString(credentials.community), message]
+            [Integer(0), OctetString(credentials.community), message]
         )
         return packet
 


### PR DESCRIPTION
The version bit for SNMPv1 was being set to `1` (which indicates SNMPv2c), when it should be `0` (indicating SNMPv1). 

Relevant issue: #36 