### PR TITLE
[docs] Sphinx v8 compatibility: configure a non-empty inventory name for Python Intersphinx mapping.

### DIFF
--- a/doc/conf.py
+++ b/doc/conf.py
@@ -54,7 +54,7 @@ html_theme = "sphinx_rtd_theme"
 html_static_path = ["_static"]
 
 intersphinx_mapping = {
-    "": ("https://docs.python.org/3/", None),
+    "python": ("https://docs.python.org/3/", None),
     "x690": ("https://exhuma.github.io/x690/", None),
     "puresnmp-crypto": ("https://exhuma.github.io/puresnmp-crypto/", None),
 }


### PR DESCRIPTION
From [Sphinx](https://github.com/sphinx-doc/sphinx/) version 8.0 onwards, some legacy behaviours of the `intersphinx_mapping` configuration setting will be dropped, and validation of Intersphinx mapping names is being tightened to require non-empty mapping names.

Based on a [code search on GitHub](https://github.com/search?q=path%3Aconf.py+intersphinx_mapping+%2F%5E%5B+%5D*%5B%27%22%5D%5B%27%22%5D%3A+%5C%28%2F&type=code) I discovered your project as one that is recently-maintained and has an `intersphinx_mapping` configuration containing an empty-string name entry.  Because only a small number of source repositories are affected, I'm opening pull requests to offer corresponding configuration updates.

Note: I'm unfamiliar with the details of the `puresnmp` documentation, so the extent of my testing has been:

  * Install a minimal set of dependencies for the project.
  * Created an empty directory `doc/_static` from the repository base path, because the build failed without this in place.
  * Build the project as HTML using Sphinx v7.4.7 (the latest and perhaps last pre-v8.x release).
  * Confirmed that the documentation build succeeded.

There were also a few warnings related to HTTP 404s for content referenced at `https://exhuma.github.io/` during the build; I haven't investigated these but they may also be fixable in (or at least relevant to) your `intersphinx_mapping` configuration.